### PR TITLE
build: exclude test files from distribution

### DIFF
--- a/package.config.ts
+++ b/package.config.ts
@@ -13,4 +13,5 @@ export default defineConfig({
       'ae-missing-release-tag': 'off',
     },
   },
+  tsconfig: 'tsconfig.lib.json',
 })

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Sanity.io <hello@sanity.io>",
   "exports": {
     ".": {
-      "types": "./lib/src/index.d.ts",
+      "types": "./lib/index.d.ts",
       "source": "./src/index.ts",
       "import": "./lib/index.esm.js",
       "require": "./lib/index.js",
@@ -35,7 +35,7 @@
   "main": "./lib/index.js",
   "module": "./lib/index.esm.js",
   "source": "./src/index.ts",
-  "types": "./lib/src/index.d.ts",
+  "types": "./lib/index.d.ts",
   "files": [
     "src",
     "lib",
@@ -43,8 +43,8 @@
     "sanity.json"
   ],
   "scripts": {
-    "prebuild": "npm run clean && plugin-kit verify-package --silent && pkg-utils",
-    "build": "pkg-utils build --strict",
+    "prebuild": "npm run clean && plugin-kit verify-package --silent",
+    "build": "pkg-utils build --strict && pkg-utils --strict",
     "clean": "rimraf lib",
     "compile": "tsc --noEmit",
     "format": "prettier src -w",
@@ -108,7 +108,9 @@
   "sanityExchangeUrl": "https://www.sanity.io/plugins/code-input",
   "sanityPlugin": {
     "verifyPackage": {
-      "babelConfig": false
+      "babelConfig": false,
+      "scripts": false,
+      "tsconfig": false
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,10 @@
 {
+  "extends": "./tsconfig.settings",
+  "include": ["src"],
   "compilerOptions": {
-    "jsx": "preserve",
-    "moduleResolution": "node",
-    "target": "esnext",
-    "module": "esnext",
-    "esModuleInterop": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "strict": true,
-    "sourceMap": false,
-    "inlineSourceMap": false,
-    "downlevelIteration": true,
-    "declaration": true,
-    "allowSyntheticDefaultImports": true,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
+    "rootDir": "src",
     "outDir": "lib",
-    "skipLibCheck": true,
-    "isolatedModules": true,
-    "checkJs": false,
-    "rootDir": "src"
-  },
-  "include": ["src/**/*"]
+    "jsx": "preserve",
+    "noEmit": true
+  }
 }

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["src"],
+  "exclude": [
+    "src/**/__fixtures__",
+    "src/**/__mocks__",
+    "src/**/__workshop__",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+    "jsx": "preserve",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  }
+}

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "target": "esnext",
+    "module": "esnext",
+    "esModuleInterop": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "strict": true,
+    "downlevelIteration": true,
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true,
+    "isolatedModules": true
+  }
+}


### PR DESCRIPTION
This PR makes it so the following file patterns are not included when transpiling TS &rarr; JS & TS definitions:

```
src/**/__fixtures__
src/**/__mocks__
src/**/__workshop__
src/**/*.test.ts
src/**/*.test.tsx
```

It does so by splitting `tsconfig.json` into `tsconfig.lib.json` and a shared settings configuration in `tsconfig.settings.json`.

Other changes:
- Run `pkg-utils --strict` _after_ build. This will add a test which checks that all the files exist at the right paths.
- Disabled some `plugin-kit` checks to be allowed to modify tsconfig and npm scripts.