### PR TITLE
fix: remove incorrect autocomplete from GROQ

### DIFF
--- a/src/codemirror/defaultCodeModes.ts
+++ b/src/codemirror/defaultCodeModes.ts
@@ -11,7 +11,7 @@ export const defaultCodeModes: CodeMode[] = [
   {
     name: 'groq',
     loader: () =>
-      import('@codemirror/lang-javascript').then(({javascript}) => javascript({jsx: false})),
+      import('@codemirror/lang-javascript').then(({javascriptLanguage}) => javascriptLanguage),
   },
   {
     name: 'javascript',


### PR DESCRIPTION
FIXES SDX-1176

Per one of the mantainers of the CodeMirror package, removing the undesired autocomplete behavior means [removing the support package of the language](https://discuss.codemirror.net/t/how-to-disable-autocomplete-on-codemirror-6/7829).

I've done that in this PR. I'm not intimately familiar with CodeMirror, but it seems only including the parser is what we need here, since we're NOT in a javascript context but want indentation, highlighting, and other behaviors. That's what I observed is maintained from manual testing, but would love some eyes on any gotchas.