### PR TITLE
fix: warnings from styled-components on language input render

### DIFF
--- a/src/LanguageField.tsx
+++ b/src/LanguageField.tsx
@@ -1,8 +1,14 @@
 import {useCallback} from 'react'
-import {FieldMember, InputProps, MemberField, MemberFieldProps, StringInputProps} from 'sanity'
+import {
+  FieldMember,
+  type InputProps,
+  MemberField,
+  type MemberFieldProps,
+  type PrimitiveInputElementProps,
+} from 'sanity'
 
 import {LanguageInput} from './LanguageInput'
-import {CodeInputLanguage} from './types'
+import type {CodeInputLanguage} from './types'
 
 export function LanguageField(
   props: MemberFieldProps & {member: FieldMember; language: string; languages: CodeInputLanguage[]},
@@ -10,10 +16,11 @@ export function LanguageField(
   const {member, languages, language, renderItem, renderField, renderPreview} = props
 
   const renderInput = useCallback(
-    (inputProps: Omit<InputProps, 'renderDefault'>) => {
+    ({elementProps, onChange}: Omit<InputProps, 'renderDefault'>) => {
       return (
         <LanguageInput
-          {...(inputProps as StringInputProps)}
+          onChange={onChange}
+          elementProps={elementProps as PrimitiveInputElementProps}
           language={language}
           languages={languages}
         />

--- a/src/LanguageInput.tsx
+++ b/src/LanguageInput.tsx
@@ -1,17 +1,19 @@
 import {Select} from '@sanity/ui'
-import {ChangeEvent, useCallback} from 'react'
-import {set, StringInputProps, unset} from 'sanity'
+import {type ChangeEvent, useCallback} from 'react'
+import {set, type StringInputProps, unset} from 'sanity'
 
 import {CodeInputLanguage} from './types'
 
-export interface LanguageInputProps extends StringInputProps {
+export interface LanguageInputProps {
   language: string
   languages: CodeInputLanguage[]
+  onChange: StringInputProps['onChange']
+  elementProps: StringInputProps['elementProps']
 }
 
 /** @internal */
 export function LanguageInput(props: LanguageInputProps) {
-  const {language, languages, onChange} = props
+  const {language, languages, onChange, elementProps} = props
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
@@ -22,7 +24,7 @@ export function LanguageInput(props: LanguageInputProps) {
   )
 
   return (
-    <Select {...props} value={language} onChange={handleChange}>
+    <Select {...elementProps} value={language} onChange={handleChange}>
       {languages.map((lang: {title: string; value: string}) => (
         <option key={lang.value} value={lang.value}>
           {lang.title}


### PR DESCRIPTION
A large number of warnings were being printed because props were being spread onto the `<Select>` component that it did not support. This PR is more careful about what it passes on, and also adds a few missing attributes, such as `id` and `aria-describedby`.