### PR TITLE
feat: add sql to supported languages

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ export const SUPPORTED_LANGUAGES: CodeInputLanguage[] = [
   {title: 'SASS', value: 'sass'},
   {title: 'SCSS', value: 'scss'},
   {title: 'sh', value: 'sh'},
+  {title: 'SQL', value: 'sql'},
   {title: 'TSX', value: 'tsx'},
   {title: 'TypeScript', value: 'typescript'},
   {title: 'XML', value: 'xml'},


### PR DESCRIPTION
I installed this project and was surprised that SQL wasn't in the default list of languages.

![CleanShot 2025-01-16 at 17 00 21@2x](https://github.com/user-attachments/assets/ad180f14-7c83-46f6-9b4e-7282e6749467)

In looking into adding it myself, I discovered that it's actually [installed and supported on this project in the code modes file](https://github.com/sanity-io/code-input/blob/main/src/codemirror/defaultCodeModes.ts#L41C3-L41C85) but for some reason it just didn't get included.

So _I believe_ this should add it.