### PR TITLE
fix(deps): allow studio v4 in peer dep ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
       "peerDependencies": {
         "react": "^18 || >=19.0.0-0",
         "react-dom": "^18 || >=19.0.0-0",
-        "sanity": "^3",
+        "sanity": "^3 || ^4.0.0-0",
         "styled-components": "^5.2 || ^6"
       }
     },

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   "peerDependencies": {
     "react": "^18 || >=19.0.0-0",
     "react-dom": "^18 || >=19.0.0-0",
-    "sanity": "^3",
+    "sanity": "^3 || ^4.0.0-0",
     "styled-components": "^5.2 || ^6"
   },
   "engines": {


### PR DESCRIPTION
### Description

Prepping for July 15th: https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason#299526b398ec

Currently when using a package.json like: 
```json
{
  "dependencies": {
    "sanity": "4.0.0-0"
  }
}
```
Running `pnpm install --resolution-only` yields peer dep issues:
```bash
.
└─┬ @sanity/code-input 5.1.2
  └── ✕ unmet peer sanity@^3: found 4.0.0-0
```
This fixes it.

### Testing

Tested locally
